### PR TITLE
Adding aggregate score breakdown to panelist score breakdown

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,7 +20,7 @@ from wwdtm.show import info as show_info
 from reports.panel import aggregate_scores, gender_mix
 
 #region Global Constants
-APP_VERSION = "1.3.0.1"
+APP_VERSION = "1.3.1"
 
 #endregion
 
@@ -125,10 +125,9 @@ def panelists_index():
 def panelists_aggregate_scores():
     """Panelists Aggregate Scores Graph Page"""
     database_connection.reconnect()
-    score, count = aggregate_scores.retrieve_score_spread(database_connection)
+    agg_scores = aggregate_scores.retrieve_score_spread(database_connection)
     return render_template("panelists/aggregate-scores/graph.html",
-                           score=score,
-                           count=count)
+                           aggregate_scores=agg_scores)
 
 @app.route("/panelists/appearances-by-year")
 def panelists_appearances_by_year_index():
@@ -181,12 +180,14 @@ def panelists_score_breakdown_details(panelist: Text):
     info = pnl_info.retrieve_by_slug(panelist, database_connection)
     scores = pnl_info.retrieve_scores_grouped_list_by_slug(panelist,
                                                            database_connection)
-    if not info and not scores:
+    agg_scores = aggregate_scores.retrieve_score_spread(database_connection)
+    if not info and not scores and not agg_scores:
         return redirect(url_for("panelists_score_breakdown_index"))
 
     return render_template("panelists/score-breakdown/details.html",
                            info=info,
-                           scores=scores)
+                           scores=scores,
+                           aggregate_scores=agg_scores)
 
 @app.route("/panelists/scores-by-appearance")
 def panelists_scores_by_appearance_index():

--- a/reports/panel/aggregate_scores.py
+++ b/reports/panel/aggregate_scores.py
@@ -28,12 +28,12 @@ def retrieve_score_spread(database_connection: mysql.connector.connect
     if not result:
         return None
 
-    score = []
-    count = []
+    scores = []
+    counts = []
     for row in result:
-        score.append(row[0])
-        count.append(row[1])
+        scores.append(row[0])
+        counts.append(row[1])
 
-    return score, count
+    return {"scores": scores, "counts": counts}
 
 #endregion

--- a/templates/panelists/aggregate-scores/graph.html
+++ b/templates/panelists/aggregate-scores/graph.html
@@ -9,7 +9,7 @@
 
 <h1>Aggregate Scores</h1>
 
-{% if score %}
+{% if aggregate_scores.scores %}
 <p>
     This chart displays the score breakdown for all panelists scores.
 </p>
@@ -35,11 +35,11 @@
 
     // Define chart data and draw settings
     var barChartData = {
-        labels: {{ score|safe }},
+        labels: {{ aggregate_scores.scores|safe }},
         datasets: [{
             label: 'Count',
             backgroundColor: '#1170aa',
-            data: {{ count|safe }}
+            data: {{ aggregate_scores.counts|safe }}
         }]
     };
 
@@ -87,7 +87,6 @@
                             fontSize: 18,
                             fontStyle: 'bold'
                         },
-                        stacked: true,
                         ticks: {
                             minRotation: 0,
                             maxRotation: 0
@@ -100,8 +99,7 @@
                             labelString: 'Count',
                             fontSize: 18,
                             fontStyle: 'bold'
-                        },
-                        stacked: true
+                        }
                     }]
                 },
                 title: {

--- a/templates/panelists/appearances-by-year/details.html
+++ b/templates/panelists/appearances-by-year/details.html
@@ -40,11 +40,10 @@
     var barChartData = {
         labels: {{ years|safe }},
         datasets: [{
-            label: 'Appearances',
             backgroundColor: '#1170aa',
-            data: {{ count|safe }}
+            data: {{ count|safe }},
+            label: 'Appearances'
         }]
-
     };
 
     // Set up and render the chart
@@ -103,10 +102,9 @@
                             fontSize: 18,
                             fontStyle: 'bold'
                         },
-                        stacked: true,
                         ticks: {
-                            minRotation: 0,
-                            maxRotation: 0
+                            minRotation: 45,
+                            maxRotation: 45
                         },
                     }],
                     yAxes: [{
@@ -129,11 +127,11 @@
                     display: true,
                     fontSize: 20,
                     fontStyle: 'bold',
-                    text: 'Appearances by Year for {{ info.name }}'
+                    text: "Appearances by Year for {{ info.name|safe }}"
                 },
                 tooltips: {
-                    mode: 'nearest',
-                    intersect: true,
+                    mode: 'index',
+                    intersect: false,
                     titleFontStyle: 'bold'
                 }
             }

--- a/templates/panelists/score-breakdown/details.html
+++ b/templates/panelists/score-breakdown/details.html
@@ -48,7 +48,7 @@
             data: {{ scores.count|safe }},
             order: 1,
             label: 'Count',
-            yAxisID: 'y-score',
+            yAxisID: 'y-score'
         }, {
             backgroundColor: '#fc7d0b',
             borderColor: '#fc7d0b',
@@ -119,7 +119,6 @@
                             fontSize: 18,
                             fontStyle: 'bold'
                         },
-                        stacked: true,
                         ticks: {
                             minRotation: 0,
                             maxRotation: 0
@@ -158,7 +157,7 @@
                     display: true,
                     fontSize: 20,
                     fontStyle: 'bold',
-                    text: 'Score Breakdown for {{ info.name }}'
+                    text: "Score Breakdown for {{ info.name|safe }}"
                 },
                 tooltips: {
                     mode: 'index',

--- a/templates/panelists/score-breakdown/details.html
+++ b/templates/panelists/score-breakdown/details.html
@@ -10,11 +10,15 @@
 
 <h1>{{ info.name }}</h1>
 
-{% if scores %}
+{% if scores and aggregate_scores.scores %}
 <p>
     This chart displays the count of how many times
-    <a href="{{ stats_url}}/panelists/{{ info.slug }}">{{ info.name }}</a>
+    <a href="{{ stats_url }}/panelists/{{ info.slug }}">{{ info.name }}</a>
     earned a specific number of points at the end of each show.
+</p>
+<p>The orange line represents
+    <a href="{{ url_for('panelists_aggregate_scores') }}">aggregate score
+    breakdown</a> for all panelists.
 </p>
 
 <p class="hide-on-large-only">
@@ -40,11 +44,23 @@
     var barChartData = {
         labels: {{ scores.score|safe }},
         datasets: [{
-            label: 'Score',
             backgroundColor: '#1170aa',
-            data: {{ scores.count|safe }}
+            data: {{ scores.count|safe }},
+            order: 1,
+            label: 'Count',
+            yAxisID: 'y-score',
+        }, {
+            backgroundColor: '#fc7d0b',
+            borderColor: '#fc7d0b',
+            data: {{ aggregate_scores.counts|safe }},
+            fill: false,
+            pointRadius: 5,
+            label: 'Aggregate Count',
+            lineTension: 0.25,
+            order: 0,
+            type: 'line',
+            yAxisID: 'y-aggregate'
         }]
-
     };
 
     // Set up and render the chart
@@ -111,6 +127,8 @@
                     }],
                     yAxes: [{
                         gridLines: { color: gridLinesColor },
+                        id: 'y-score',
+                        position: 'left',
                         scaleLabel: {
                             display: true,
                             labelString: 'Count',
@@ -123,6 +141,17 @@
                             suggestedMax: yAxisMax,
                             stepSize: yAxisTickStepSize
                         }
+                    }, {
+                        display: true,
+                        id: 'y-aggregate',
+                        gridLines: { drawOnChartArea: false },
+                        position: 'right',
+                        scaleLabel: {
+                            display: true,
+                            labelString: 'Aggregate Count',
+                            fontSize: 18,
+                            fontStyle: 'bold'
+                        }
                     }]
                 },
                 title: {
@@ -132,8 +161,8 @@
                     text: 'Score Breakdown for {{ info.name }}'
                 },
                 tooltips: {
-                    mode: 'nearest',
-                    intersect: true,
+                    mode: 'index',
+                    intersect: false,
                     titleFontStyle: 'bold'
                 }
             }

--- a/templates/panelists/scores-by-appearance/details.html
+++ b/templates/panelists/scores-by-appearance/details.html
@@ -38,7 +38,7 @@
 
     // Define chart data and draw settings
     var data_obj = {{ scores|safe }};
-    if (data_obj.length >= 40) {
+    if (data_obj.length >= 50) {
         var showLine = false;
     } else {
         var showLine = true;

--- a/templates/panelists/scores-by-appearance/details.html
+++ b/templates/panelists/scores-by-appearance/details.html
@@ -37,18 +37,24 @@
     });
 
     // Define chart data and draw settings
+    var data_obj = {{ scores|safe }};
+    if (data_obj.length >= 40) {
+        var showLine = false;
+    } else {
+        var showLine = true;
+    }
     var lineChartData = {
         labels: {{ shows|safe }},
         datasets: [{
             backgroundColor: '#1170aa',
             borderColor: '#1170aa',
-            data: {{ scores|safe }},
+            data: data_obj,
             fill: false,
             label: 'Score',
             lineTension: 0.25,
             pointBorderColor: '#f5f5f5',
             pointRadius: 5,
-            showLine: true
+            showLine: showLine
         }]
     };
 

--- a/templates/panelists/scores-by-appearance/details.html
+++ b/templates/panelists/scores-by-appearance/details.html
@@ -139,10 +139,10 @@
                     display: true,
                     fontSize: 20,
                     fontStyle: 'bold',
-                    text: 'Scores by Appearance for {{ info.name }}'
+                    text: "Scores by Appearance for {{ info.name|safe }}"
                 },
                 tooltips: {
-                    mode: 'nearest',
+                    mode: 'index',
                     intersect: false,
                     titleFontStyle: 'bold'
                 }

--- a/templates/panelists/scores-by-appearance/details.html
+++ b/templates/panelists/scores-by-appearance/details.html
@@ -38,7 +38,7 @@
 
     // Define chart data and draw settings
     var data_obj = {{ scores|safe }};
-    if (data_obj.length >= 50) {
+    if (data_obj.length >= 30) {
         var showLine = false;
     } else {
         var showLine = true;


### PR DESCRIPTION
Adding a line graph representing the aggregate score breakdown for all panelists on top of the individual panelist score breakdown bar graph to add some additional insight into how well a panelist has performed over the years

Including code cleanup on the JavaScript side for defining charts and fixed display issue for panelists with an apostrophe in their name in the chart title.