### PR TITLE
Revamp page breadcrumbs

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ from graphs import utility
 from reports.panel import aggregate_scores, gender_mix
 
 #region Global Constants
-APP_VERSION = "1.4.0.1"
+APP_VERSION = "1.5.0"
 
 #endregion
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -17,7 +17,11 @@
     .container { max-width: initial; width: 95%; }
     .dropdown-content { border: 2px solid rgba(0, 0, 0, 0.1); }
     .dropdown-content li>a, .dropdown-content li>span { color: initial; }
-    .page-breadcrumb { margin: 1rem 0; }
+    .page-breadcrumb { background-color: rgba(96, 96, 96, 0.05); margin: 1.25rem 0; padding: 0.25rem 1rem; }
+    .page-breadcrumb ul { list-style: none; padding: 0; }
+    .page-breadcrumb ul li { display: inline; padding: 0; }
+    .page-breadcrumb ul li:first-child { padding: 0 0.5rem 0 0; }
+    .page-breadcrumb ul li:not(:last-child)::after { content: ">"; margin: 0 0.75rem;  }
     .sidenav .divider { margin: 1rem 0; }
     .sidenav ul#sidenav-show-years { margin-left: 1rem; }
     .sidenav li>a { font-size: initial; font-weight: initial; }
@@ -28,6 +32,7 @@
 
 @media (prefers-color-scheme: light) {
     html, button, input, select, textarea { background-color: initial; color: initial; }
+    .page-breadcrumb { background-color: rgba(160, 160, 160, 0.1); }
 }
 
 @media (prefers-color-scheme: dark) {
@@ -49,6 +54,7 @@
 
 @media only screen and (max-width: 600px) {
     .collection .collection-item { padding: 1.33rem; }
+    .page-breadcrumb { font-size: 110%; line-height: 2.5rem;}
     nav .brand-logo { font-size: 1.0rem; font-weight: 500; left: 45%; transform: translateX(-40%); }
     .col.s12 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
     .footer-copyright span.right { display: block; float: initial !important; }
@@ -56,5 +62,5 @@
 
 @media only print {
     html { margin: 1rem; }
-    nav, div.sidenav { display: none; visibility: hidden; }
+    nav, div.sidenav, .page-breadcrumb { display: none; visibility: hidden; }
 }

--- a/templates/panelists/aggregate-scores/graph.html
+++ b/templates/panelists/aggregate-scores/graph.html
@@ -3,8 +3,17 @@
 
 {% block content %}
 <div class="page-breadcrumb hide-on-small-only">
-    <a href="{{ url_for('index') }}">Home</a> &gt;
-    <a href="{{ url_for('panelists_index') }}">Panelists</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            <a href="{{ url_for('panelists_index') }}">Panelists</a>
+        </li>
+        <li>
+            Aggregate Scores
+        </li>
+    </ul>
 </div>
 
 <h1>Aggregate Scores</h1>

--- a/templates/panelists/appearances-by-year/details.html
+++ b/templates/panelists/appearances-by-year/details.html
@@ -3,9 +3,20 @@
 
 {% block content %}
 <div class="page-breadcrumb hide-on-small-only">
-    <a href="{{ url_for('index') }}">Home</a> &gt;
-    <a href="{{ url_for('panelists_index') }}">Panelists</a> &gt;
-    <a href="{{ url_for('panelists_appearances_by_year_index') }}">Appearances by Year</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            <a href="{{ url_for('panelists_index') }}">Panelists</a>
+        </li>
+        <li>
+            <a href="{{ url_for('panelists_appearances_by_year_index') }}">Appearances by Year</a>
+        </li>
+        <li>
+            {{ info.name }}
+        </li>
+    </ul>
 </div>
 
 <h1>{{ info.name }}</h1>

--- a/templates/panelists/appearances-by-year/index.html
+++ b/templates/panelists/appearances-by-year/index.html
@@ -3,8 +3,17 @@
 
 {% block content %}
 <div class="page-breadcrumb hide-on-small-only">
-    <a href="{{ url_for('index') }}">Home</a> &gt;
-    <a href="{{ url_for('panelists_index') }}">Panelists</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            <a href="{{ url_for('panelists_index') }}">Panelists</a>
+        </li>
+        <li>
+            Appearances by Year
+        </li>
+    </ul>
 </div>
 
 <h1>Appearances by Year</h1>

--- a/templates/panelists/index.html
+++ b/templates/panelists/index.html
@@ -3,7 +3,14 @@
 
 {% block content %}
 <div class="page-breadcrumb hide-on-small-only">
-    <a href="{{ url_for('index') }}">Home</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            Panelists
+        </li>
+    </ul>
 </div>
 
 <h1>Panelists</h1>

--- a/templates/panelists/score-breakdown/details.html
+++ b/templates/panelists/score-breakdown/details.html
@@ -3,9 +3,20 @@
 
 {% block content %}
 <div class="page-breadcrumb hide-on-small-only">
-    <a href="{{ url_for('index') }}">Home</a> &gt;
-    <a href="{{ url_for('panelists_index') }}">Panelists</a> &gt;
-    <a href="{{ url_for('panelists_score_breakdown_index') }}">Score Breakdown</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            <a href="{{ url_for('panelists_index') }}">Panelists</a>
+        </li>
+        <li>
+            <a href="{{ url_for('panelists_score_breakdown_index') }}">Score Breakdown</a>
+        </li>
+        <li>
+            {{ info.name }}
+        </li>
+    </ul>
 </div>
 
 <h1>{{ info.name }}</h1>

--- a/templates/panelists/score-breakdown/index.html
+++ b/templates/panelists/score-breakdown/index.html
@@ -3,8 +3,17 @@
 
 {% block content %}
 <div class="page-breadcrumb hide-on-small-only">
-    <a href="{{ url_for('index') }}">Home</a> &gt;
-    <a href="{{ url_for('panelists_index') }}">Panelists</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            <a href="{{ url_for('panelists_index') }}">Panelists</a>
+        </li>
+        <li>
+            Score Breakdown
+        </li>
+    </ul>
 </div>
 
 <h1>Score Breakdown</h1>

--- a/templates/panelists/scores-by-appearance/details.html
+++ b/templates/panelists/scores-by-appearance/details.html
@@ -3,9 +3,20 @@
 
 {% block content %}
 <div class="page-breadcrumb hide-on-small-only">
-    <a href="{{ url_for('index') }}">Home</a> &gt;
-    <a href="{{ url_for('panelists_index') }}">Panelists</a> &gt;
-    <a href="{{ url_for('panelists_scores_by_appearance_index') }}">Scores by Appearance</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            <a href="{{ url_for('panelists_index') }}">Panelists</a>
+        </li>
+        <li>
+            <a href="{{ url_for('panelists_scores_by_appearance_index') }}">Scores by Appearance</a>
+        </li>
+        <li>
+            {{ info.name }}
+        </li>
+    </ul>
 </div>
 
 <h1>{{ info.name }}</h1>

--- a/templates/panelists/scores-by-appearance/index.html
+++ b/templates/panelists/scores-by-appearance/index.html
@@ -3,8 +3,17 @@
 
 {% block content %}
 <div class="page-breadcrumb hide-on-small-only">
-    <a href="{{ url_for('index') }}">Home</a> &gt;
-    <a href="{{ url_for('panelists_index') }}">Panelists</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            <a href="{{ url_for('panelists_index') }}">Panelists</a>
+        </li>
+        <li>
+            Scores by Appearance
+        </li>
+    </ul>
 </div>
 
 <h1>Scores by Appearance</h1>

--- a/templates/shows/all-scores/details.html
+++ b/templates/shows/all-scores/details.html
@@ -3,9 +3,20 @@
 
 {% block content %}
 <div class="page-breadcrumb hide-on-small-only">
-    <a href="{{ url_for('index') }}">Home</a> &gt;
-    <a href="{{ url_for('shows_index') }}">Shows</a> &gt;
-    <a href="{{ url_for('shows_all_scores') }}">All Scores</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            <a href="{{ url_for('shows_index') }}">Shows</a>
+        </li>
+        <li>
+            <a href="{{ url_for('shows_all_scores') }}">All Scores</a>
+        </li>
+        <li>
+            {{ year }}
+        </li>
+    </ul>
 </div>
 
 <h1>All Scores for {{ year }}</h1>

--- a/templates/shows/all-scores/index.html
+++ b/templates/shows/all-scores/index.html
@@ -3,8 +3,17 @@
 
 {% block content %}
 <div class="page-breadcrumb hide-on-small-only">
-    <a href="{{ url_for('index') }}">Home</a> &gt;
-    <a href="{{ url_for('shows_index') }}">Shows</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            <a href="{{ url_for('shows_index') }}">Shows</a>
+        </li>
+        <li>
+            All Scores
+        </li>
+    </ul>
 </div>
 
 <h1>Shows</h1>

--- a/templates/shows/index.html
+++ b/templates/shows/index.html
@@ -3,7 +3,14 @@
 
 {% block content %}
 <div class="page-breadcrumb hide-on-small-only">
-    <a href="{{ url_for('index') }}">Home</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            Shows
+        </li>
+    </ul>
 </div>
 
 <h1>Shows</h1>

--- a/templates/shows/panel-gender-mix/graph.html
+++ b/templates/shows/panel-gender-mix/graph.html
@@ -3,8 +3,17 @@
 
 {% block content %}
 <div class="page-breadcrumb hide-on-small-only">
-    <a href="{{ url_for('index') }}">Home</a> &gt;
-    <a href="{{ url_for('shows_index') }}">Shows</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            <a href="{{ url_for('shows_index') }}">Shows</a>
+        </li>
+        <li>
+            Panel Gender Mix
+        </li>
+    </ul>
 </div>
 
 <h1>Panel Gender Mix</h1>


### PR DESCRIPTION
Porting over the newly revamped page breadcrumbs from stats.wwdt.me; but, keeping the .hide-on-small-only on DVI.page-breadcrumb in order to display as much of the chart on mobile as possible