### PR TITLE
Remove mobile message and set xaxis tickangle explicitly

### DIFF
--- a/templates/panelists/aggregate-scores/graph.html
+++ b/templates/panelists/aggregate-scores/graph.html
@@ -23,10 +23,6 @@
     This chart displays the score breakdown for all panelists scores.
 </p>
 
-<p class="hide-on-large-only">
-    Note: This chart is best viewed in landscape mode on mobile and tablet devices.
-</p>
-
 <div id="ww-chart"></div>
 
 <script>
@@ -84,6 +80,7 @@
         },
         xaxis: {
             color: axisColor,
+            tickangle: 0,
             tickfont: { size: 16 },
             tickmode: "linear",
             title: {

--- a/templates/panelists/appearances-by-year/details.html
+++ b/templates/panelists/appearances-by-year/details.html
@@ -28,10 +28,6 @@
     has made an appearance on the show, broken down by year.
 </p>
 
-<p class="hide-on-large-only">
-    Note: This chart is best viewed in landscape mode on mobile and tablet devices.
-</p>
-
 <div id="ww-chart"></div>
 
 <script>

--- a/templates/panelists/score-breakdown/details.html
+++ b/templates/panelists/score-breakdown/details.html
@@ -32,10 +32,6 @@
     breakdown</a> for all panelists.
 </p>
 
-<p class="hide-on-large-only">
-    Note: This chart is best viewed in landscape mode on mobile and tablet devices.
-</p>
-
 <div id="ww-chart"></div>
 
 <script>

--- a/templates/panelists/scores-by-appearance/details.html
+++ b/templates/panelists/scores-by-appearance/details.html
@@ -28,10 +28,6 @@
     appearances on the show, excluding Best Of and Repeat Shows.
 </p>
 
-<p class="hide-on-large-only">
-    Note: This chart is best viewed in landscape mode on mobile and tablet devices.
-</p>
-
 <div id="ww-chart"></div>
 
 <script>

--- a/templates/shows/all-scores/details.html
+++ b/templates/shows/all-scores/details.html
@@ -27,10 +27,6 @@
     excluding Best Ofs and Repeat shows.
 </p>
 
-<p class="hide-on-large-only">
-    Note: This chart is best viewed in landscape mode on mobile and tablet devices.
-</p>
-
 <div id="ww-chart"></div>
 
 <script>

--- a/templates/shows/bluff-counts/all.html
+++ b/templates/shows/bluff-counts/all.html
@@ -28,10 +28,6 @@
     month.
 </p>
 
-<p class="hide-on-large-only">
-    Note: This chart is best viewed in landscape mode on mobile and tablet devices.
-</p>
-
 <div id="ww-chart"></div>
 
 <script>

--- a/templates/shows/bluff-counts/details.html
+++ b/templates/shows/bluff-counts/details.html
@@ -27,10 +27,6 @@
     the correct or incorrect Bluff the Listener story, broken down by month.
 </p>
 
-<p class="hide-on-large-only">
-    Note: This chart is best viewed in landscape mode on mobile and tablet devices.
-</p>
-
 <div id="ww-chart"></div>
 
 <script>

--- a/templates/shows/panel-gender-mix/graph.html
+++ b/templates/shows/panel-gender-mix/graph.html
@@ -23,10 +23,6 @@
     This chart displays the gender mix of the panels broken out by year.
 </p>
 
-<p class="hide-on-large-only">
-    Note: This chart is best viewed in landscape mode on mobile and tablet devices.
-</p>
-
 <div id="ww-chart"></div>
 
 <script>


### PR DESCRIPTION
With the switch to Plotly.js, the mobile-only message is no longer needed. Also, explicitly set xaxis tickangle as implied value may cause weird behavior on smaller screens