### PR TITLE
Switch from Math.max() to Math.max.apply() to fix IE

### DIFF
--- a/templates/panelists/appearances-by-year/details.html
+++ b/templates/panelists/appearances-by-year/details.html
@@ -45,7 +45,7 @@
     // Set y-axis dtick value
     let yAxisdTick = 2;
     let appearanceCounts = {{ count|safe }};
-    let maxCount = Math.max(...appearanceCounts);
+    let maxCount = Math.max.apply(Math, appearanceCounts);
     if (maxCount <= 3) {
         yAxisdTick = 1;
     }

--- a/templates/panelists/score-breakdown/details.html
+++ b/templates/panelists/score-breakdown/details.html
@@ -49,7 +49,7 @@
     // Set y-axis dtick value
     let yAxisdTick = 2;
     let scoreCounts = {{ scores.count|safe }};
-    let maxCount = Math.max(...scoreCounts);
+    let maxCount = Math.max.apply(Math, scoreCounts);
     if (maxCount <= 3) {
         yAxisdTick = 1;
     }


### PR DESCRIPTION
IE 11 doesn't understand Math.max(...array) and that breaks some of the graphs. Switch to using Math.max.apply(Math, array) instead