### PR TITLE
Set y-axis to fixedrange and remove zoom in/out buttons

### DIFF
--- a/templates/panelists/aggregate-scores/graph.html
+++ b/templates/panelists/aggregate-scores/graph.html
@@ -90,6 +90,7 @@
         },
         yaxis: {
             color: axisColor,
+            fixedrange: true,
             tickfont: { size: 16 },
             title: {
                 font: { size: 18 },
@@ -100,6 +101,10 @@
 
     let config = {
         displaylogo: false,
+        modeBarButtonsToRemove: [
+            "zoomIn2d",
+            "zoomOut2d"
+        ],
         responsive: true,
         toImageButtonOptions: {
             filename: "aggregate-scores",

--- a/templates/panelists/appearances-by-year/details.html
+++ b/templates/panelists/appearances-by-year/details.html
@@ -104,6 +104,7 @@
         yaxis: {
             dtick: yAxisdTick,
             color: axisColor,
+            fixedrange: true,
             tickfont: { size: 16 },
             title: {
                 font: { size: 18 },
@@ -114,6 +115,10 @@
 
     let config = {
         displaylogo: false,
+        modeBarButtonsToRemove: [
+            "zoomIn2d",
+            "zoomOut2d"
+        ],
         responsive: true,
         toImageButtonOptions: {
             filename: "appearances-by-year-{{ info.slug }}",

--- a/templates/panelists/score-breakdown/details.html
+++ b/templates/panelists/score-breakdown/details.html
@@ -114,6 +114,7 @@
         yaxis: {
             color: axisColor,
             dtick: yAxisdTick,
+            fixedrange: true,
             tickfont: { size: 16 },
             title: {
                 font: { size: 18 },
@@ -140,6 +141,10 @@
 
     let config = {
         displaylogo: false,
+        modeBarButtonsToRemove: [
+            "zoomIn2d",
+            "zoomOut2d"
+        ],
         responsive: true,
         toImageButtonOptions: {
             filename: "score-breakdown-{{ info.slug }}",

--- a/templates/panelists/scores-by-appearance/details.html
+++ b/templates/panelists/scores-by-appearance/details.html
@@ -97,6 +97,7 @@
         yaxis: {
             color: axisColor,
             dtick: 2,
+            fixedrange: true,
             tickfont: { size: 16 },
             range: [0, 22],
             title: {
@@ -108,6 +109,10 @@
 
     let config = {
         displaylogo: false,
+        modeBarButtonsToRemove: [
+            "zoomIn2d",
+            "zoomOut2d"
+        ],
         responsive: true,
         toImageButtonOptions: {
             filename: "scores-by-appearance-{{ info.slug }}",

--- a/templates/shows/all-scores/details.html
+++ b/templates/shows/all-scores/details.html
@@ -116,6 +116,7 @@
         yaxis: {
             color: axisColor,
             dtick: 5,
+            fixedrange: true,
             tickfont: { size: 16 },
             title: {
                 font: { size: 18 },
@@ -126,6 +127,10 @@
 
     let config = {
         displaylogo: false,
+        modeBarButtonsToRemove: [
+            "zoomIn2d",
+            "zoomOut2d"
+        ],
         responsive: true,
         toImageButtonOptions: {
             filename: "all-scores-{{ year }}",

--- a/templates/shows/bluff-counts/all.html
+++ b/templates/shows/bluff-counts/all.html
@@ -110,6 +110,7 @@
         yaxis: {
             color: axisColor,
             dtick: 1,
+            fixedrange: true,
             range: [0, 6],
             tickfont: { size: 16 },
             title: {
@@ -121,6 +122,10 @@
 
     let config = {
         displaylogo: false,
+        modeBarButtonsToRemove: [
+            "zoomIn2d",
+            "zoomOut2d"
+        ],
         responsive: true,
         toImageButtonOptions: {
             filename: "bluff-counts-year-month",

--- a/templates/shows/bluff-counts/details.html
+++ b/templates/shows/bluff-counts/details.html
@@ -108,6 +108,7 @@
         yaxis: {
             color: axisColor,
             dtick: 1,
+            fixedrange: true,
             range: [0, 6],
             tickfont: { size: 16 },
             title: {
@@ -119,6 +120,10 @@
 
     let config = {
         displaylogo: false,
+        modeBarButtonsToRemove: [
+            "zoomIn2d",
+            "zoomOut2d"
+        ],
         responsive: true,
         toImageButtonOptions: {
             filename: "bluff-counts-{{ year }}",

--- a/templates/shows/panel-gender-mix/graph.html
+++ b/templates/shows/panel-gender-mix/graph.html
@@ -118,6 +118,7 @@
         yaxis: {
             color: axisColor,
             dtick: 5,
+            fixedrange: true,
             range: [0, 60],
             tickfont: { size: 16 },
             title: {
@@ -129,6 +130,10 @@
 
     let config = {
         displaylogo: false,
+        modeBarButtonsToRemove: [
+            "zoomIn2d",
+            "zoomOut2d"
+        ],
         responsive: true,
         toImageButtonOptions: {
             filename: "panel-gender-mix",


### PR DESCRIPTION
Setting the y-axis to fixedrange to limit the scaling and zooming to be within the range of data in the graph. Removing zoom in/out buttons from modebar to remove clutter and to focus on existing zoom features.