### PR TITLE
Adding meta theme-color header and updating footer with tooltips

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ import pytz
 from slugify import slugify
 from werkzeug.exceptions import HTTPException
 
+from wwdtm import VERSION as WWDTM_VERSION
 from wwdtm.panelist import info as pnl_info
 from wwdtm.show import info as show_info
 from graphs import utility
@@ -22,7 +23,7 @@ from reports.panel import aggregate_scores, gender_mix
 from reports.show import bluff_count as bluff, scores as show_scores
 
 #region Global Constants
-APP_VERSION = "1.8.0.1"
+APP_VERSION = "1.8.1"
 
 #endregion
 
@@ -425,6 +426,7 @@ config = load_config()
 app_time_zone = config["settings"]["app_time_zone"]
 time_zone_name = config["settings"]["time_zone"]
 app.jinja_env.globals["app_version"] = APP_VERSION
+app.jinja_env.globals["libwwdtm_version"] = WWDTM_VERSION
 app.jinja_env.globals["current_date"] = date.today()
 app.jinja_env.globals["ga_property_code"] = config["settings"]["ga_property_code"]
 app.jinja_env.globals["time_zone"] = app_time_zone

--- a/templates/core/footer.html
+++ b/templates/core/footer.html
@@ -14,7 +14,11 @@
     <div class="footer-copyright">
         <div class="container">
             Copyright &copy; 2007&ndash;{{ current_year(time_zone) }} <a href="http://linhpham.org/">Linh Pham</a>. All rights reserved.
-            <span class="right">R: {{ rendered_at(time_zone) }} | V: {{ app_version }}</span>
+            <span class="right">
+                <span title="Page Rendered at Time">R: {{ rendered_at(time_zone) }}</span> |
+                <span title="Application Version">V: {{ app_version }}</span> |
+                <span title="libwwdtm Version">L: {{ libwwdtm_version }}</span>
+            </span>
         </div>
     </div>
 </footer>

--- a/templates/core/head.html
+++ b/templates/core/head.html
@@ -1,5 +1,6 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="theme-color" content="#0d47a1">
 <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
 {% if site_url and request.path %}
 <link rel="canonical" href="{{ site_url}}{{ request.path }}">


### PR DESCRIPTION
Adding `<meta name="theme-color">` to header to enable theme color support in upcoming version of Safari. Also, updated footer to include tooltips over "R", "V" and "L" info.