### PR TITLE
Adding Show Counts by Day of Month Charts

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,6 +21,7 @@ from wwdtm.show import info as show_info
 from graphs import utility
 from reports.panel import aggregate_scores, gender_mix
 from reports.show import (bluff_count as bluff,
+                          dates,
                           scores as show_scores,
                           show_counts)
 
@@ -116,6 +117,7 @@ def sitemap_xml():
     show_years = retrieve_show_years(reverse_order=False)
     panelists = pnl_info.retrieve_all(database_connection)
     sitemap = render_template("core/sitemap.xml",
+                              months=utility.month_names.keys(),
                               show_years=show_years,
                               panelists=panelists)
     return Response(sitemap, mimetype="text/xml")
@@ -349,10 +351,51 @@ def shows_bluff_counts_by_year(year: int):
                            correct=correct,
                            incorrect=incorrect)
 
+@app.route("/shows/counts-by-day-month")
+def shows_counts_by_day_of_month_index():
+    """Counts by Day of Month Graph Index Page"""
+    database_connection.reconnect()
+    return render_template("shows/counts-by-day-month/index.html",
+                           months=utility.month_names)
+
+@app.route("/shows/counts-by-day-month/<int:month>")
+def shows_counts_by_day_of_month(month: int):
+    """Counts by Day of Month Graph"""
+    database_connection.reconnect()
+
+    # Validate that the month number is valid
+    if not month in range(1, 13):
+        return redirect(url_for("shows_counts_by_day_of_month"))
+
+    shows_month = dates.retrieve_show_counts_by_month_day(month,
+                                                          database_connection)
+
+    if not shows_month:
+        return redirect(url_for("shows_counts_by_day_of_month"))
+
+    days = []
+    regular_shows = []
+    best_of_shows = []
+    repeat_shows = []
+    repeat_best_of_shows = []
+    for day, value in shows_month.items():
+        days.append(day)
+        regular_shows.append(value["regular"])
+        best_of_shows.append(value["best_of"])
+        repeat_shows.append(value["repeat"])
+        repeat_best_of_shows.append(value["best_of_repeat"])
+
+    return render_template("shows/counts-by-day-month/details.html",
+                           month=utility.month_names[month],
+                           days=days,
+                           regular_shows=regular_shows,
+                           best_of_shows=best_of_shows,
+                           repeat_shows=repeat_shows,
+                           repeat_best_of_shows=repeat_best_of_shows)
+
 @app.route("/shows/monthly-aggregate-score-heatmap")
 def shows_monthly_aggregate_score_heatmap():
     """Monthly Aggregate Score Heatmap Graph"""
-
     database_connection.reconnect()
     all_scores = show_scores.retrieve_monthly_aggregate_scores(database_connection)
 

--- a/app.py
+++ b/app.py
@@ -26,7 +26,7 @@ from reports.show import (bluff_count as bluff,
                           show_counts)
 
 #region Global Constants
-APP_VERSION = "1.11.0"
+APP_VERSION = "1.12.0"
 
 #endregion
 

--- a/app.py
+++ b/app.py
@@ -365,13 +365,13 @@ def shows_counts_by_day_of_month(month: int):
 
     # Validate that the month number is valid
     if not month in range(1, 13):
-        return redirect(url_for("shows_counts_by_day_of_month"))
+        return redirect(url_for("shows_counts_by_day_of_month_index"))
 
     shows_month = dates.retrieve_show_counts_by_month_day(month,
                                                           database_connection)
 
     if not shows_month:
-        return redirect(url_for("shows_counts_by_day_of_month"))
+        return redirect(url_for("shows_counts_by_day_of_month_index"))
 
     days = []
     regular_shows = []

--- a/graphs/utility.py
+++ b/graphs/utility.py
@@ -7,6 +7,12 @@ from datetime import datetime
 from dateutil import parser
 import pytz
 
+month_names = {
+    1: "January", 2: "February", 3: "March", 4: "April",
+    5: "May", 6: "June", 7: "July", 8: "August",
+    9: "September", 10: "October", 11: "November", 12: "December"
+}
+
 #region Date/Time Functions
 def current_year(time_zone: pytz.timezone = pytz.timezone("UTC")):
     """Return the current year"""

--- a/reports/__init__.py
+++ b/reports/__init__.py
@@ -4,7 +4,7 @@
 """Explicitly listing all reporting modules"""
 
 from reports.panel import aggregate_scores, gender_mix
-from reports.show import bluff_count, scores, show_counts
+from reports.show import bluff_count, dates, scores, show_counts
 
 __all__ = [
     "panel",

--- a/reports/show/__init__.py
+++ b/reports/show/__init__.py
@@ -3,10 +3,11 @@
 # graphs.wwdt.me is relased under the terms of the Apache License 2.0
 """Explicitly listing all show graphing modules"""
 
-from reports.show import bluff_count, scores, show_counts
+from reports.show import bluff_count, dates, scores, show_counts
 
 __all__ = [
     "bluff_count",
+    "dates",
     "scores",
     "show_counts"
 ]

--- a/reports/show/dates.py
+++ b/reports/show/dates.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2018-2021 Linh Pham
+# reports.wwdt.me is relased under the terms of the Apache License 2.0
+"""WWDTM Show Dates Retrieval Functions"""
+
+from collections import OrderedDict
+from typing import Dict
+import mysql.connector
+
+#region Utility Functions
+def build_days_of_month_dict(month: int) -> Dict:
+    """Returns an OrderedDict containing a key for each day for a given
+    month, each containing an OrderedDict used to store counts by show
+    type"""
+
+    # Validate that the month number is valid
+    if not month in range(1, 13):
+        return None
+
+    if month == 2:
+        days_in_month = 29
+    elif month in [1, 3, 5, 7, 8, 10, 12]:
+        days_in_month = 31
+    else:
+        days_in_month = 30
+
+    month = OrderedDict()
+    for day in range(1, days_in_month + 1):
+        show_info = OrderedDict()
+        show_info["regular"] = 0
+        show_info["best_of"] = 0
+        show_info["repeat"] = 0
+        show_info["best_of_repeat"] = 0
+        month[day] = show_info
+
+    return month
+
+#endregion
+
+#region Retrieval Functions
+def retrieve_show_counts_by_month_day(month: int,
+                                      database_connection: mysql.connector.connect
+                                     ) -> Dict:
+    """Retrieves an OrderedDict containing a count of regular shows,
+    Best Of shows, repeat shows and repeat Best Of shows for each day
+    of the requested month"""
+
+    # Validate that the month number is valid
+    if not month in range(1, 13):
+        return None
+
+    show_month = build_days_of_month_dict(month)
+    if not show_month:
+        return None
+
+    cursor = database_connection.cursor(dictionary=True)
+    query = ("SELECT DAY(showdate) AS day, bestof, repeatshowid FROM ww_shows "
+             "WHERE MONTH(showdate) = %s "
+             "ORDER BY DAY(showdate) ASC;")
+    cursor.execute(query, (month, ))
+    results = cursor.fetchall()
+    cursor.close()
+
+    if not results:
+        return None
+
+    for row in results:
+        day = row["day"]
+        best_of = bool(row["bestof"])
+        repeat_show = bool(row["repeatshowid"])
+
+        if not best_of and not repeat_show:
+            show_month[day]["regular"] += 1
+        elif best_of and not repeat_show:
+            show_month[day]["best_of"] += 1
+        elif not best_of and repeat_show:
+            show_month[day]["repeat"] += 1
+        elif best_of and repeat_show:
+            show_month[day]["best_of_repeat"] += 1
+
+    return show_month
+
+#endregion

--- a/reports/show/dates.py
+++ b/reports/show/dates.py
@@ -56,6 +56,7 @@ def retrieve_show_counts_by_month_day(month: int,
     cursor = database_connection.cursor(dictionary=True)
     query = ("SELECT DAY(showdate) AS day, bestof, repeatshowid FROM ww_shows "
              "WHERE MONTH(showdate) = %s "
+             "AND showdate <= NOW() "
              "ORDER BY DAY(showdate) ASC;")
     cursor.execute(query, (month, ))
     results = cursor.fetchall()

--- a/templates/core/nav.html
+++ b/templates/core/nav.html
@@ -14,6 +14,7 @@
         <ul id="dropdown-show" class="dropdown-content z-depth-0">
             <li><a href="{{ url_for('shows_all_scores') }}">All Scores</a></li>
             <li><a href="{{ url_for('shows_bluff_counts') }}">Bluff Counts</a></li>
+            <li><a href="{{ url_for('shows_counts_by_day_of_month_index') }}">Counts by Day of Month</a></li>
             <li><a href="{{ url_for('shows_counts_by_year') }}">Counts by Year</a></li>
             <li><a href="{{ url_for('shows_monthly_aggregate_score_heatmap') }}">Monthly Aggregate Scores</a></li>
             <li><a href="{{ url_for('shows_monthly_average_score_heatmap') }}">Monthly Average Scores</a></li>

--- a/templates/core/sitemap.xml
+++ b/templates/core/sitemap.xml
@@ -67,6 +67,16 @@
   </url>
 {% endfor %}
   <url>
+    <loc>{{ site_url }}{{ url_for("shows_counts_by_day_of_month_index") }}</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+{% for month in months %}
+  <url>
+    <loc>{{ site_url }}{{ url_for("shows_counts_by_day_of_month", month=month) }}</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+{% endfor %}
+  <url>
     <loc>{{ site_url }}{{ url_for("shows_counts_by_year") }}</loc>
     <changefreq>weekly</changefreq>
   </url>

--- a/templates/shows/counts-by-day-month/details.html
+++ b/templates/shows/counts-by-day-month/details.html
@@ -1,0 +1,170 @@
+{% extends "base.html" %}
+{% set page_title="Counts by Day of Month" %}
+{% block title %}{{ month }} | {{ page_title}} | Shows{% endblock %}
+
+{% block content %}
+<div class="page-breadcrumb hide-on-small-only">
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            <a href="{{ url_for('shows_index') }}">Shows</a>
+        </li>
+        <li>
+            <a href="{{ url_for('shows_counts_by_day_of_month_index') }}">{{ page_title }}</a>
+        </li>
+        <li>
+            {{ month }}
+        </li>
+    </ul>
+</div>
+
+<h1>Counts by Day of Month for {{ month }}</h1>
+
+{% if days and regular_shows %}
+<p>
+    This chart displays the number of shows that have aired for a specific day
+    of month, broken out by regular shows, Best Of shows, repeat shows, and
+    repeat Best Of shows.
+</p>
+
+<div id="ww-chart"></div>
+
+<script>
+    // Set default colors and font list
+    let axisColor = "#212121";
+    let backgroundColor = "#fff";
+    let fontList = "'IBM Plex Sans', 'Helvetica Neue', sans-serif";
+
+    // Change colors if in dark mode
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        axisColor = "#f5f5f5";
+        backgroundColor = "#202124";
+    }
+
+    let days = {{ days|safe }};
+    let regular_shows = {{ regular_shows|safe }};
+    let best_of_shows = {{ best_of_shows|safe }};
+    let repeat_shows = {{ repeat_shows|safe }};
+    let repeat_best_of_shows = {{ repeat_best_of_shows|safe }};
+
+    let data = [
+        {
+            x: days,
+            y: regular_shows,
+            name: "Regular",
+            type: "bar"
+        },
+        {
+            x: days,
+            y: best_of_shows,
+            name: "Best Of",
+            type: "bar"
+        },
+        {
+            x: days,
+            y: repeat_shows,
+            name: "Repeat",
+            type: "bar"
+        },
+        {
+            x: days,
+            y: repeat_best_of_shows,
+            name: "Repeat Best Of",
+            type: "bar"
+        }
+    ];
+
+    let layout = {
+        autosize: true,
+        barmode: "stack",
+        colorway: [
+            "#1f77b4",
+            "#70ad47",
+            
+            "#ff7f0e",
+            "#ffc000",
+        ],
+        font: { family: fontList },
+        hoverlabel: {
+            font: {
+                family: fontList,
+                size: 16
+            },
+        },
+        hovermode: "x",
+        legend: {
+            font: {
+                color: axisColor,
+                family: fontList,
+                size: 16
+            },
+            traceorder: "normal",
+        },
+        margin: {
+            l: 60,
+            r: 40,
+            t: 48,
+            b: 90
+        },
+        paper_bgcolor: backgroundColor,
+        plot_bgcolor: backgroundColor,
+        showlegend: true,
+        title: {
+            font: {
+                color: axisColor,
+                size: 20
+            },
+            text: "{{ page_title }} for {{ month }}"
+        },
+        xaxis: {
+            color: axisColor,
+            showspikes: true,
+            spikecolor: axisColor,
+            spikedash: "dot",
+            spikemode: "across",
+            spikethickness: 1,
+            tickfont: { size: 14 },
+            title: {
+                font: { size: 18 },
+                text: "Day of Month"
+            },
+            type: "category"
+        },
+        yaxis: {
+            color: axisColor,
+            dtick: 1,
+            fixedrange: true,
+            tickfont: { size: 16 },
+            title: {
+                font: { size: 18 },
+                text: "Shows"
+            }
+        }
+    };
+
+    let config = {
+        displaylogo: false,
+        modeBarButtonsToRemove: [
+            "zoomIn2d",
+            "zoomOut2d"
+        ],
+        responsive: true,
+        toImageButtonOptions: {
+            filename: "counts-by-day-month-{{ month }}".toLowerCase(),
+            height: 800,
+            scale: 1,
+            width: 1200
+        }
+    };
+
+    Plotly.newPlot("ww-chart", data, layout, config);
+</script>
+{% else %}
+<p>
+    No show count data available.
+</p>
+{% endif %}
+
+{% endblock %}

--- a/templates/shows/counts-by-day-month/index.html
+++ b/templates/shows/counts-by-day-month/index.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% set page_title="Counts by Day of Month" %}
+{% block title %}{{ page_title }} | Shows{% endblock %}
+
+{% block content %}
+<div class="page-breadcrumb hide-on-small-only">
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            <a href="{{ url_for('shows_index') }}">Shows</a>
+        </li>
+        <li>
+            {{ page_title }}
+        </li>
+    </ul>
+</div>
+
+<h1>Months</h1>
+<p>
+    Choose from one of the months below to view the counts of shows by day of
+    month for each calendar month.
+</p>
+
+<ul class="collection">
+    {% for month in months %}
+    <li class="collection-item">
+        <a href="{{ url_for('shows_counts_by_day_of_month', month=month) }}">{{ months[month] }}</a>
+    </li>
+    {% endfor %}
+</ul>
+
+{% endblock %}

--- a/templates/shows/index.html
+++ b/templates/shows/index.html
@@ -28,6 +28,9 @@
         <a href="{{ url_for('shows_bluff_counts') }}">Bluff the Listener Counts</a>
     </li>
     <li class="collection-item">
+        <a href="{{ url_for('shows_counts_by_day_of_month_index') }}">Counts by Day of Month</a>
+    </li>
+    <li class="collection-item">
         <a href="{{ url_for('shows_counts_by_year') }}">Counts by Year</a>
     </li>
     <li class="collection-item">


### PR DESCRIPTION
The new set of charts displays the number of shows (up to the current date) that have aired for a given day of month for a given calendar month, broken out by regular, Best Of, repeat and repeat Best Of shows, in stacked bar format.