### PR TITLE
Add 404 handling and standardize use of page_title

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,7 +26,7 @@ from reports.show import (bluff_count as bluff,
                           show_counts)
 
 #region Global Constants
-APP_VERSION = "1.12.0"
+APP_VERSION = "1.13.0"
 
 #endregion
 
@@ -98,6 +98,12 @@ def handle_exception(error):
     app_logger.error(error_traceback)
     return render_template("errors/500.html",
                            error_traceback=error_traceback), 500
+
+@app.errorhandler(404)
+def not_found(error):
+    """Handle resource not found conditions"""
+    return render_template("errors/404.html",
+                           error_description=error.description), 404
 
 #endregion
 

--- a/templates/core/footer.html
+++ b/templates/core/footer.html
@@ -13,7 +13,7 @@
     </div>
     <div class="footer-copyright">
         <div class="container">
-            Copyright &copy; 2007&ndash;{{ current_year(time_zone) }} <a href="http://linhpham.org/">Linh Pham</a>. All rights reserved.
+            Copyright &copy; 2007&ndash;{{ current_year(time_zone) }} <a href="https://linhpham.org/">Linh Pham</a>. All rights reserved.
             <span class="right">
                 <span title="Page Rendered at Time">R: {{ rendered_at(time_zone) }}</span> |
                 <span title="Application Version">V: {{ app_version }}</span> |

--- a/templates/errors/404.html
+++ b/templates/errors/404.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block title %}Not Found{% endblock %}
+
+{% block content %}
+
+<h1>Oops...</h1>
+
+<p>We couldn't find what you were looking for.</p>
+
+<p>Head back to the <a href="{{ url_for('index') }}"> main page</a>.</p>
+
+{% endblock %}

--- a/templates/pages/index.html
+++ b/templates/pages/index.html
@@ -5,13 +5,25 @@
 <h1>Wait Wait Don't Tell Me! Graphs</h1>
 <p>
     This site provides a charts and graphs that represent information
-    based on the data stored in the Wait Wait Don't Tell Me! Stats Page
+    based on the data stored in the
+    <a href="{{ stats_url }}">Wait Wait Don't Tell Me! Stats Page</a>
     database.
 </p>
 
 <p>
-    The list of graphs can be found by using the top navigation bar or the
-    slide-out navigation menu.
+    You can view each of the sections of this site by using the list of
+    sections below or, depending on the device you are viewing this page on,
+    the slide-out navigation menu or the menu items in the navigation bar at
+    the top of this page.
 </p>
+
+<ul class="collection">
+    <li class="collection-item">
+        <a href="{{ url_for('panelists_index') }}">Panelists</a>
+    </li>
+    <li class="collection-item">
+        <a href="{{ url_for('shows_index') }}">Shows</a>
+    </li>
+</ul>
 
 {% endblock %}

--- a/templates/panelists/aggregate-scores/graph.html
+++ b/templates/panelists/aggregate-scores/graph.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
-{% block title %}Aggregate Score Breakdown | Panelists{% endblock %}
+{% set page_title = "Aggregate Scores" %}
+{% block title %}{{ page_title }} | Panelists{% endblock %}
 
 {% block content %}
 <div class="page-breadcrumb hide-on-small-only">
@@ -11,12 +12,12 @@
             <a href="{{ url_for('panelists_index') }}">Panelists</a>
         </li>
         <li>
-            Aggregate Scores
+            {{ page_title }}
         </li>
     </ul>
 </div>
 
-<h1>Aggregate Scores</h1>
+<h1>{{ page_title }}</h1>
 
 {% if aggregate_scores.scores %}
 <p>
@@ -77,7 +78,7 @@
                 color: axisColor,
                 size: 20
             },
-            text: "Aggregate Score Breakdown"
+            text: "{{ page_title }} Breakdown"
         },
         xaxis: {
             color: axisColor,

--- a/templates/panelists/appearances-by-year/details.html
+++ b/templates/panelists/appearances-by-year/details.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
-{% block title %}{{ info.name }} | Appearances by Year | Panelists{% endblock %}
+{% set page_title = "Appearances by Year" %}
+{% block title %}{{ info.name }} | {{ page_title }} | Panelists{% endblock %}
 
 {% block content %}
 <div class="page-breadcrumb hide-on-small-only">
@@ -11,7 +12,7 @@
             <a href="{{ url_for('panelists_index') }}">Panelists</a>
         </li>
         <li>
-            <a href="{{ url_for('panelists_appearances_by_year_index') }}">Appearances by Year</a>
+            <a href="{{ url_for('panelists_appearances_by_year_index') }}">{{ page_title }}</a>
         </li>
         <li>
             {{ info.name }}
@@ -90,7 +91,7 @@
                 color: axisColor,
                 size: 20
             },
-            text: "Appearances by Year for {{ info.name|safe }}"
+            text: "{{ page_title }} for {{ info.name|safe }}"
         },
         xaxis: {
             color: axisColor,

--- a/templates/panelists/appearances-by-year/index.html
+++ b/templates/panelists/appearances-by-year/index.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
-{% block title %}Appearances by Year | Panelists{% endblock %}
+{% set page_title = "Appearances by Year" %}
+{% block title %}{{ page_title }} | Panelists{% endblock %}
 
 {% block content %}
 <div class="page-breadcrumb hide-on-small-only">
@@ -11,12 +12,12 @@
             <a href="{{ url_for('panelists_index') }}">Panelists</a>
         </li>
         <li>
-            Appearances by Year
+            {{ page_title }}
         </li>
     </ul>
 </div>
 
-<h1>Appearances by Year</h1>
+<h1>{{ page_title }}</h1>
 <p>
     Choose from one of the panelists below to view a chart displaying
     the number of appearances broken down by year.

--- a/templates/panelists/index.html
+++ b/templates/panelists/index.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
-{% block title %}Panelists{% endblock %}
+{% set page_title = "Panelists" %}
+{% block title %}{{ page_title }}{% endblock %}
 
 {% block content %}
 <div class="page-breadcrumb hide-on-small-only">
@@ -8,12 +9,12 @@
             <a href="{{ url_for('index') }}">Home</a>
         </li>
         <li>
-            Panelists
+            {{ page_title }}
         </li>
     </ul>
 </div>
 
-<h1>Panelists</h1>
+<h1>{{ page_title }}</h1>
 <p>
     Choose from one of the following graph types to get a list of available
     panelists.

--- a/templates/panelists/score-breakdown/details.html
+++ b/templates/panelists/score-breakdown/details.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
-{% block title %}{{ info.name }} | Score Breakdown | Panelists{% endblock %}
+{% set page_title = "Score Breakdown" %}
+{% block title %}{{ info.name }} | {{ page_title }} | Panelists{% endblock %}
 
 {% block content %}
 <div class="page-breadcrumb hide-on-small-only">
@@ -11,7 +12,7 @@
             <a href="{{ url_for('panelists_index') }}">Panelists</a>
         </li>
         <li>
-            <a href="{{ url_for('panelists_score_breakdown_index') }}">Score Breakdown</a>
+            <a href="{{ url_for('panelists_score_breakdown_index') }}">{{ page_title }}</a>
         </li>
         <li>
             {{ info.name }}
@@ -100,7 +101,7 @@
                 color: axisColor,
                 size: 20
             },
-            text: "Score Breakdown for {{ info.name|safe }}"
+            text: "{{ page_title }} for {{ info.name|safe }}"
         },
         xaxis: {
             color: axisColor,

--- a/templates/panelists/score-breakdown/index.html
+++ b/templates/panelists/score-breakdown/index.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
-{% block title %}Score Breakdown | Panelists{% endblock %}
+{% set page_title = "Score Breakdown" %}
+{% block title %}{{ page_title }} | Panelists{% endblock %}
 
 {% block content %}
 <div class="page-breadcrumb hide-on-small-only">
@@ -11,12 +12,12 @@
             <a href="{{ url_for('panelists_index') }}">Panelists</a>
         </li>
         <li>
-            Score Breakdown
+            {{ page_title }}
         </li>
     </ul>
 </div>
 
-<h1>Score Breakdown</h1>
+<h1>{{ page_title }}</h1>
 <p>
     Choose from one of the panelists below to view a chart displaying a
     breakdown of their scores.

--- a/templates/panelists/scores-by-appearance/details.html
+++ b/templates/panelists/scores-by-appearance/details.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
-{% block title %}{{ info.name }} | Scores by Appearance | Panelists{% endblock %}
+{% set page_title = "Scores by Appearance" %}
+{% block title %}{{ info.name }} | {{ page_title }} | Panelists{% endblock %}
 
 {% block content %}
 <div class="page-breadcrumb hide-on-small-only">
@@ -11,7 +12,7 @@
             <a href="{{ url_for('panelists_index') }}">Panelists</a>
         </li>
         <li>
-            <a href="{{ url_for('panelists_scores_by_appearance_index') }}">Scores by Appearance</a>
+            <a href="{{ url_for('panelists_scores_by_appearance_index') }}">{{ page_title }}</a>
         </li>
         <li>
             {{ info.name }}
@@ -82,7 +83,7 @@
                 color: axisColor,
                 size: 20
             },
-            text: "Scores by Appearance for {{ info.name|safe }}"
+            text: "{{ page_title }} for {{ info.name|safe }}"
         },
         xaxis: {
             color: axisColor,

--- a/templates/panelists/scores-by-appearance/index.html
+++ b/templates/panelists/scores-by-appearance/index.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
-{% block title %}Scores by Appearance | Panelists{% endblock %}
+{% set page_title = "Scores by Appearance" %}
+{% block title %}{{ page_title }} | Panelists{% endblock %}
 
 {% block content %}
 <div class="page-breadcrumb hide-on-small-only">
@@ -11,12 +12,12 @@
             <a href="{{ url_for('panelists_index') }}">Panelists</a>
         </li>
         <li>
-            Scores by Appearance
+            {{ page_title }}
         </li>
     </ul>
 </div>
 
-<h1>Scores by Appearance</h1>
+<h1>{{ page_title }}</h1>
 <p>
     Choose from one of the panelists below to view a chart displaying
     their scores for each of their appearance on the show.

--- a/templates/shows/all-scores/details.html
+++ b/templates/shows/all-scores/details.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
-{% block title %}{{ year }} | All Scores | Shows{% endblock %}
+{% set page_title = "All Scores" %}
+{% block title %}{{ year }} | {{ page_title }} | Shows{% endblock %}
 
 {% block content %}
 <div class="page-breadcrumb hide-on-small-only">
@@ -11,7 +12,7 @@
             <a href="{{ url_for('shows_index') }}">Shows</a>
         </li>
         <li>
-            <a href="{{ url_for('shows_all_scores') }}">All Scores</a>
+            <a href="{{ url_for('shows_all_scores') }}">{{ page_title }}</a>
         </li>
         <li>
             {{ year }}
@@ -19,7 +20,7 @@
     </ul>
 </div>
 
-<h1>All Scores for {{ year }}</h1>
+<h1>{{ page_title }} for {{ year }}</h1>
 
 {% if shows %}
 <p>
@@ -101,7 +102,7 @@
                 color: axisColor,
                 size: 20
             },
-            text: "All Scores for {{ year }}"
+            text: "{{ page_title }} for {{ year }}"
         },
         xaxis: {
             color: axisColor,

--- a/templates/shows/all-scores/index.html
+++ b/templates/shows/all-scores/index.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
-{% block title %}All Scores | Shows{% endblock %}
+{% set page_title = "All Scores" %}
+{% block title %}{{ page_title }} | Shows{% endblock %}
 
 {% block content %}
 <div class="page-breadcrumb hide-on-small-only">
@@ -11,14 +12,14 @@
             <a href="{{ url_for('shows_index') }}">Shows</a>
         </li>
         <li>
-            All Scores
+            {{ page_title }}
         </li>
     </ul>
 </div>
 
-<h1>Years</h1>
+<h1>{{ page_title }}</h1>
 <p>
-    Choose from one of the years below to view the available scores for that year.
+    Choose from one of the years below to view all available scores for that year.
 </p>
 
 <ul class="collection">

--- a/templates/shows/bluff-counts/all.html
+++ b/templates/shows/bluff-counts/all.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
-{% block title %}All | Bluff the Listener Counts | Shows{% endblock %}
+{% set page_title="Bluff the Listener Counts" %}
+{% block title %}All | {{ page_title }} | Shows{% endblock %}
 
 {% block content %}
 <div class="page-breadcrumb hide-on-small-only">
@@ -11,7 +12,7 @@
             <a href="{{ url_for('shows_index') }}">Shows</a>
         </li>
         <li>
-            <a href="{{ url_for('shows_bluff_counts') }}">Bluff the Listener Counts</a>
+            <a href="{{ url_for('shows_bluff_counts') }}">{{ page_title }}</a>
         </li>
         <li>
             All
@@ -19,7 +20,7 @@
     </ul>
 </div>
 
-<h1>Bluff the Listener Counts by Year and Month</h1>
+<h1>{{ page_title }} by Year and Month</h1>
 
 {% if dates %}
 <p>
@@ -95,7 +96,7 @@
                 color: axisColor,
                 size: 20
             },
-            text: "Bluff the Listener Counts by Year and Month"
+            text: "{{ page_title }} by Year and Month"
         },
         xaxis: {
             color: axisColor,

--- a/templates/shows/bluff-counts/details.html
+++ b/templates/shows/bluff-counts/details.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
-{% block title %}{{ year }} | Bluff the Listener Counts | Shows{% endblock %}
+{% set page_title="Bluff the Listener Counts" %}
+{% block title %}{{ year }} | {{ page_title }} | Shows{% endblock %}
 
 {% block content %}
 <div class="page-breadcrumb hide-on-small-only">
@@ -11,7 +12,7 @@
             <a href="{{ url_for('shows_index') }}">Shows</a>
         </li>
         <li>
-            <a href="{{ url_for('shows_bluff_counts') }}">Bluff the Listener Counts</a>
+            <a href="{{ url_for('shows_bluff_counts') }}">{{ page_title }}</a>
         </li>
         <li>
             {{ year }}
@@ -19,7 +20,7 @@
     </ul>
 </div>
 
-<h1>Bluff the Listener Counts for {{ year }}</h1>
+<h1>{{ page_title }} for {{ year }}</h1>
 
 {% if months %}
 <p>
@@ -94,7 +95,7 @@
                 color: axisColor,
                 size: 20
             },
-            text: "Bluff the Listener Counts for {{ year }}"
+            text: "{{ page_title }} for {{ year }}"
         },
         xaxis: {
             color: axisColor,

--- a/templates/shows/bluff-counts/index.html
+++ b/templates/shows/bluff-counts/index.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
-{% block title %}Bluff the Listener Counts | Shows{% endblock %}
+{% set page_title="Bluff the Listener Counts" %}
+{% block title %}{{ page_title }} | Shows{% endblock %}
 
 {% block content %}
 <div class="page-breadcrumb hide-on-small-only">
@@ -11,12 +12,12 @@
             <a href="{{ url_for('shows_index') }}">Shows</a>
         </li>
         <li>
-            Bluff the Listener Counts
+            {{ page_title }}
         </li>
     </ul>
 </div>
 
-<h1>Years</h1>
+<h1>{{ page_title }}</h1>
 <p>
     Choose from one of the years below to view the available Bluff the Listener
     counts data for that year.

--- a/templates/shows/counts-by-day-month/index.html
+++ b/templates/shows/counts-by-day-month/index.html
@@ -17,7 +17,7 @@
     </ul>
 </div>
 
-<h1>Months</h1>
+<h1>{{ page_title }}</h1>
 <p>
     Choose from one of the months below to view the counts of shows by day of
     month for each calendar month.

--- a/templates/shows/counts-by-year/graph.html
+++ b/templates/shows/counts-by-year/graph.html
@@ -111,7 +111,7 @@
                 color: axisColor,
                 size: 20
             },
-            text: "Show Counts by Year"
+            text: "{{ page_title }}"
         },
         xaxis: {
             color: axisColor,

--- a/templates/shows/index.html
+++ b/templates/shows/index.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
-{% block title %}Shows{% endblock %}
+{% set page_title = "Shows" %}
+{% block title %}{{ page_title }}{% endblock %}
 
 {% block content %}
 <div class="page-breadcrumb hide-on-small-only">
@@ -8,12 +9,12 @@
             <a href="{{ url_for('index') }}">Home</a>
         </li>
         <li>
-            Shows
+            {{ page_title }}
         </li>
     </ul>
 </div>
 
-<h1>Shows</h1>
+<h1>{{ page_title }}</h1>
 
 <p>
     Choose from one of the following links to view graphs representing data

--- a/templates/shows/monthly-aggregate-score-heatmap/graph.html
+++ b/templates/shows/monthly-aggregate-score-heatmap/graph.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
-{% block title %}Monthly Aggregate Score Heatmap | Shows{% endblock %}
+{% set page_title="Monthly Aggregate Score Heatmap" %}
+{% block title %}{{ page_title }} | Shows{% endblock %}
 
 {% block content %}
 <div class="page-breadcrumb hide-on-small-only">
@@ -11,12 +12,12 @@
             <a href="{{ url_for('shows_index') }}">Shows</a>
         </li>
         <li>
-            Monthly Aggregate Score Heatmap
+            {{ page_title }}
         </li>
     </ul>
 </div>
 
-<h1>Monthly Aggregate Score Heatmap</h1>
+<h1>{{ page_title }}</h1>
 
 {% if years and scores %}
 <p>
@@ -102,7 +103,7 @@
                 color: axisColor,
                 size: 20
             },
-            text: "Monthly Aggregate Score Heatmap"
+            text: "{{ page_title }}"
         },
         xaxis: {
             color: axisColor,

--- a/templates/shows/monthly-average-score-heatmap/graph.html
+++ b/templates/shows/monthly-average-score-heatmap/graph.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
-{% block title %}Monthly Average Score Heatmap | Shows{% endblock %}
+{% set page_title="Monthly Average Score Heatmap" %}
+{% block title %}{{ page_title }} | Shows{% endblock %}
 
 {% block content %}
 <div class="page-breadcrumb hide-on-small-only">
@@ -11,12 +12,12 @@
             <a href="{{ url_for('shows_index') }}">Shows</a>
         </li>
         <li>
-            Monthly Average Score Heatmap
+            {{ page_title }}
         </li>
     </ul>
 </div>
 
-<h1>Monthly Average Score Heatmap</h1>
+<h1>{{ page_title }}</h1>
 
 {% if years and scores %}
 <p>
@@ -104,7 +105,7 @@
                 color: axisColor,
                 size: 20
             },
-            text: "Monthly Average Score Heatmap"
+            text: "{{ page_title }}"
         },
         xaxis: {
             color: axisColor,

--- a/templates/shows/panel-gender-mix/graph.html
+++ b/templates/shows/panel-gender-mix/graph.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
-{% block title %}Panel Gender Mix | Shows{% endblock %}
+{% set page_title="Panel Gender Mix" %}
+{% block title %}{{ page_title }} | Shows{% endblock %}
 
 {% block content %}
 <div class="page-breadcrumb hide-on-small-only">
@@ -11,12 +12,12 @@
             <a href="{{ url_for('shows_index') }}">Shows</a>
         </li>
         <li>
-            Panel Gender Mix
+            {{ page_title }}
         </li>
     </ul>
 </div>
 
-<h1>Panel Gender Mix</h1>
+<h1>{{ page_title }}</h1>
 
 {% if years %}
 <p>
@@ -104,7 +105,7 @@
                 color: axisColor,
                 size: 20
             },
-            text: "Panel Gender Mix"
+            text: "{{ page_title }}"
         },
         xaxis: {
             color: axisColor,


### PR DESCRIPTION
Add 404 content not found error handling, using the 404 template file from Wait Wait Stats Page.

Also, standardize the use of `page_title` across all pages throughout the site to reduce places where page title needs to be updated if changes are needed.